### PR TITLE
fix: de-duplicate shm references

### DIFF
--- a/t/sanity.t
+++ b/t/sanity.t
@@ -425,7 +425,7 @@ failed to lock: nil key
 --- request
 GET /t
 --- response_body
-4
+1
 --- no_error_log
 [error]
 --- skip_eval: 3: system("$NginxBinary -V 2>&1 | grep -- '--with-debug'") ne 0


### PR DESCRIPTION
Store a permanent reference to the lock shm object instead of using the memo table with the lock keys. Reduces the size+churn on the memo table by 50%.

This is greatly optimizes the happy path (when the lock is explicitly `unlock()`-ed by the caller and not by gc) because no table operations are done during garbage collection in this case. This makes `resty.lock` much less susceptible to memo table fragmentation.